### PR TITLE
callback "imageUpdated" is triggered indefinitely (img.onload on a loop)

### DIFF
--- a/src/js/picedit.js
+++ b/src/js/picedit.js
@@ -419,14 +419,21 @@
 			if(file) img.file = file;
 			img.src = datasrc;
 			img.onload = function() {
+				var image = null;
 				if(dataurl) {
                     var canvas = document.createElement('canvas');
                     var ctx = canvas.getContext('2d');
                     canvas.width = img.width;
                     canvas.height = img.height;
                     ctx.drawImage(img, 0, 0);
-                    img.src = canvas.toDataURL('image/png');
+                    image = document.createElement("img");
+                    image.src = canvas.toDataURL('image/png');
                 }
+				if ( image != null){
+					_this._image = image;
+				}else{
+					_this._image = img;
+				}
                 _this._image = img;
 				_this._resizeViewport();
 				_this._paintCanvas();

--- a/src/js/picedit.js
+++ b/src/js/picedit.js
@@ -429,12 +429,9 @@
                     image = document.createElement("img");
                     image.src = canvas.toDataURL('image/png');
                 }
-				if ( image != null){
-					_this._image = image;
-				}else{
-					_this._image = img;
-				}
-                _this._image = img;
+				
+				_this._image = ( image != null) ? image : img; 
+
 				_this._resizeViewport();
 				_this._paintCanvas();
 				_this.options.imageUpdated(_this._image);


### PR DESCRIPTION
Hi Andrei!

first of all, I want to thank you for the great monster you have created, it is awesome, please welcome the first pull request. 
I've noticed that when the method : _create_image_with_datasrc: function(datasrc, callback, file, dataurl)
is called with the 4 parameters and dataurl = true
it happens that:
"img.onload" is triggered infinite times and the callback "imageUpdated" is also called in a loop.
This commit tries to fix that. Please consider to merge the pull request or not.

thanks & regards,