### PR TITLE
Prevent recursivelly triggering img.onload

### DIFF
--- a/src/js/picedit.js
+++ b/src/js/picedit.js
@@ -433,6 +433,7 @@
 				_this.options.imageUpdated(_this._image);
 				_this._mainbuttons.removeClass("active");
 				if(callback && typeof(callback) == "function") callback();
+				img.onload=null;
 			};
 		},
 		// Functions to controll cropping functionality (drag & resize cropping box)


### PR DESCRIPTION
Hi! I just noticed in my project that if I set a defaultImage when initializing picEdit, I couldn't change it. It's because the plugin was overriding the new picture with the default one. Adding a console.log(1) to the function assigned to img.onload on line 421, I also noticed that img.onload was kicking itself infinite times, so I just added this img.onload=null; at the end of the event so it is called just once after a picture change.

Cheers!
