### PR TITLE
Bugfix: close button not visible

### DIFF
--- a/src/js/picedit.js
+++ b/src/js/picedit.js
@@ -240,14 +240,18 @@
 		set_messagebox: function (text, autohide, closebutton) {
 			autohide = typeof autohide !== 'undefined' ? autohide : 3000;
 			closebutton = typeof closebutton !== 'undefined' ? closebutton : true;
-			var classes = "active";
-			if(!closebutton) classes += " no_close_button";
+			this._messagebox.addClass("active");
+			if(closebutton) {
+				this._messagebox.removeClass("no_close_button");
+			} else {
+				this._messagebox.addClass("no_close_button");
+			}
 			if(autohide) {
 				clearTimeout(this._messagetimeout);
 				var _this = this;
 				this._messagetimeout = setTimeout(function(){ _this.hide_messagebox(); }, autohide);
 			}
-			return this._messagebox.addClass(classes).children("div").html(text);
+			return this._messagebox.children("div").html(text);
 		},
 		// Toggle button and update variables
 		toggle_button: function (elem) {


### PR DESCRIPTION
After popping up a message with no close button, the messagebox div keeps the class "no_close_button" anyway and the button does not show. When calling set_messagebox with closebutton=true, this._messagebox will have the class "no_close_button" removed. To reproduce this bug, make the form post to a non existent address (cause a 404 error).