### PR TITLE
Use defaultImage filename

### DIFF
--- a/src/js/picedit.js
+++ b/src/js/picedit.js
@@ -222,6 +222,7 @@
         // Set the default Image
         set_default_image: function (path) {
             this._create_image_with_datasrc(path, false, false, true);
+            this._filename = path;
         },
 		// Remove all notification copy and hide message box
 		hide_messagebox: function () {


### PR DESCRIPTION
If you just load something as defaultImage and upload straight after, the filename posted is just "image.png"