### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Once you're done with the image manipulations you can just upload the form as us
 <h6><i>Note: Due to limitations of HTML5 Form API the form will be submitted with XMLHttpRequest/Ajax. The submission is handled by picEdit. If your form uses any js plugins or custom javascript this can create issues!</i></h6>
 
 See the demo here: https://andyvr.github.io/picEdit/
-###Usage Example
+### Usage Example
 
 **Include jquery, the plugin js and css files**
 
@@ -57,7 +57,7 @@ See the demo here: https://andyvr.github.io/picEdit/
 ```
 
 
-###Available methods and options
+### Available methods and options
 
 **defaultImage**
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
