### PR TITLE
createObjectURL bug fixed: picedit.js

### DIFF
--- a/src/js/picedit.js
+++ b/src/js/picedit.js
@@ -374,7 +374,9 @@
 				},
 				function(stream) {
 					var videoElement = _this._videobox.find("video")[0];
-					videoElement.src = URL.createObjectURL(stream);
+					//videoElement.src = URL.createObjectURL(stream);
+					videoElement.srcObject = stream;
+					videoElement.play();
 					//resize viewport
 					videoElement.onloadedmetadata = function() {
 						if(videoElement.videoWidth && videoElement.videoHeight) {


### PR DESCRIPTION
TypeError: Failed to execute 'createObjectURL' on 'URL': Overload resolution failed.
bug fixed